### PR TITLE
Pricing now uses the last-loaded producer

### DIFF
--- a/lib/merit/calculator.rb
+++ b/lib/merit/calculator.rb
@@ -112,16 +112,9 @@ module Merit
 
         if max_load < remaining
           assign_load(producer, point, max_load)
-        elsif remaining > 0.0
-          assign_load(producer, point, remaining)
-
-          # Cost-function producers with at least one unit of capacity available
-          # will be the price-setting producer.
-          if producer.cost_strategy.price_setting?(point)
-            assign_price_setting(order, producer, point)
-            break
-          end
         else
+          assign_load(producer, point, remaining) if remaining > 0
+
           assign_price_setting(order, producer, point)
 
           # Optimisation: If all of the demand has been accounted for, there

--- a/spec/merit/calculator_spec.rb
+++ b/spec/merit/calculator_spec.rb
@@ -139,8 +139,8 @@ module Merit
         expect(load_value).to eql(volatile_two.max_load_at(0))
       end
 
-      it 'assigns the price setting producer with the next dispatchable' do
-        expect(order.price_setting_producers[0]).to eql(dispatchable_two)
+      it 'assigns the price setting with the last-loaded producer' do
+        expect(order.price_setting_producers[0]).to eql(dispatchable)
       end
 
       context 'and the dispatchable is a cost-function producer' do
@@ -149,8 +149,8 @@ module Merit
         end
 
         context 'with no remaining capacity' do
-          it 'assigns the next dispatchable as price-setting' do
-            expect(order.price_setting_producers[0]).to eql(dispatchable_two)
+          it 'assigns the dispatchable as price-setting' do
+            expect(order.price_setting_producers[0]).to eql(dispatchable)
           end
         end # with no remaining capacity
 

--- a/spec/merit/cost_strategy_spec.rb
+++ b/spec/merit/cost_strategy_spec.rb
@@ -50,11 +50,6 @@ module Merit::CostStrategy ; describe Merit::CostStrategy do
       it 'calculates the price to be equal to the marginal cost' do
         expect(strategy.price_at(0)).to eq(100.0)
       end
-
-      it 'raises an error when the producer has non-zero load' do
-        expect { strategy.price_at(1) }.
-          to raise_error(Merit::InsufficentCapacityForPrice)
-      end
     end # price
   end # Constant
 
@@ -104,16 +99,9 @@ module Merit::CostStrategy ; describe Merit::CostStrategy do
 
     describe '#price' do
       context 'when the producer does not provide a price' do
-        it 'calculates the price for one additional plant' do
-          expect(strategy.price_at(0)).to eq(99.6)
-          expect(strategy.price_at(1)).to eq(100.8)
-        end
-
-        it 'raises an error when there is insufficient remaining capacity' do
-          producer.load_curve.set(0, 91.0)
-
-          expect { strategy.price_at(0) }.
-            to raise_error(Merit::InsufficentCapacityForPrice)
+        it 'calculates the price using current production' do
+          expect(strategy.price_at(0)).to eq(99.4)
+          expect(strategy.price_at(1)).to eq(100.6)
         end
       end # when the producer does not provide a price
 
@@ -174,11 +162,6 @@ module Merit::CostStrategy ; describe Merit::CostStrategy do
 
       it 'gets the cost from the curve' do
         expect(strategy.price_at(0)).to eq(250.0)
-      end
-
-      it 'raises an error when the producer has non-zero load' do
-        expect { strategy.price_at(2) }.
-          to raise_error(Merit::InsufficentCapacityForPrice)
       end
     end # price
   end # FromCurve


### PR DESCRIPTION
Instead of setting the hourly price by the first producer to not have
any load assigned, we now set the price using the most expensive
producer to be given a load.

Ref quintel/merit-convergence#2