### PR TITLE
Loosened limit for blackout hours

### DIFF
--- a/lib/merit/blackout.rb
+++ b/lib/merit/blackout.rb
@@ -3,7 +3,7 @@ module Merit
     include NetLoadHelper
 
     def number_of_hours
-      net_load.count { |val| val < -1e-10 }
+      net_load.count { |val| val < -1e-5 }
     end
   end
 end


### PR DESCRIPTION
This solves the issue described in https://github.com/quintel/etmodel/issues/2179. As described in https://github.com/quintel/etmodel/issues/2179#issuecomment-237576570, this problem was caused by a numerical error.

I tested that after this fix https://github.com/quintel/etmodel/issues/2179 is resolved.

Closes https://github.com/quintel/etmodel/issues/2179.