### PR TITLE
Loosened limit for excess event hours

### DIFF
--- a/lib/merit/excess.rb
+++ b/lib/merit/excess.rb
@@ -32,7 +32,7 @@ module Merit
     private
 
     def over_producing
-      -> (point) { point > 1e-10 }
+      -> (point) { point > 1e-5 }
     end
 
     def events


### PR DESCRIPTION
The commit in this pull request makes the excess event hour calculation in line with the recent change to the blackout hour calculation in https://github.com/quintel/merit/commit/a76e65814caa882eb27be6e64a7d74cf24036083.