### PR TITLE
Limit the discharge of storage to output capacity left

### DIFF
--- a/lib/merit/flex/storage.rb
+++ b/lib/merit/flex/storage.rb
@@ -45,7 +45,9 @@ module Merit
         return 0.0 if @load_curve.get(point).negative?
 
         in_reserve = @reserve.at(point) * @output_efficiency
-        in_reserve > @output_capacity ? @output_capacity : in_reserve
+        output_capacity_left = @output_capacity - @load_curve.get(point)
+
+        in_reserve > output_capacity_left ? output_capacity_left : in_reserve
       end
 
       # Public: Assigns the load to the storage technology and retains the energy in the reserve for

--- a/spec/factories/flex.rb
+++ b/spec/factories/flex.rb
@@ -27,5 +27,10 @@ FactoryBot.define do
     factory :variable_consumer, class: 'Merit::Flex::VariableConsumer' do
       initialize_with { Merit::Flex::VariableConsumer.new(attributes) }
     end
+
+    factory :export do
+      consume_from_dispatchables { true }
+      output_capacity_per_unit { 0.0 }
+    end
   end
 end

--- a/spec/integration/storage_spec.rb
+++ b/spec/integration/storage_spec.rb
@@ -17,10 +17,11 @@ RSpec.describe 'Calculation of storage' do
     let(:store_1) do
       FactoryBot.build(
         :storage,
-        input_capacity_per_unit: 10.0,
-        output_capacity_per_unit: 10.0,
+        input_capacity_per_unit: 10.0, #why then load_curve MIN becomes -20? would make more sense for its MAX to be 20
+        output_capacity_per_unit: 20.0,
         marginal_costs: storage_1_prices[:out],
         consumption_price: storage_1_prices[:in],
+        decay: ->(*) { 0.0 },
         volume_per_unit: 100.0
       )
     end
@@ -66,6 +67,14 @@ RSpec.describe 'Calculation of storage' do
       it 'discharges from the higher-priced store last' do
         expect(store_1.load_at(1)).to eq(3)
       end
+
+      it 'never exceeds the output capcity of the first store' do
+        expect(store_1.load_curve.values.max).to be <= store_1.output_capacity_per_unit
+      end
+
+      it 'never exceeds the output capcity of the second store' do
+        expect(store_2.load_curve.values.max).to be <= store_2.output_capacity_per_unit
+      end
     end
 
     context 'when a participant has different charge and discharge prices' do
@@ -87,6 +96,64 @@ RSpec.describe 'Calculation of storage' do
       it 'discharges from the higher-priced store last' do
         expect(store_2.load_at(1)).to eq(0)
       end
+
+      it 'never exceeds the output capcity of the first store' do
+        expect(store_1.load_curve.values.max).to be <= store_1.output_capacity_per_unit
+      end
+
+      it 'never exceeds the output capcity of the second store' do
+        expect(store_2.load_curve.values.max).to be <= store_2.output_capacity_per_unit
+      end
+    end
+  end
+
+  context 'when there is export availability' do
+    let(:export) do
+      FactoryBot.build(
+        :export,
+        cost_curve: Merit::Curve.new([1.0, 0.0, 0.0, 0.9, 1.7] * 1752),
+        input_capacity_per_unit: 30.0
+      )
+    end
+
+    let(:producer) do
+      FactoryBot.build(
+        :curve_producer,
+        load_curve: Merit::Curve.new([40.0, 10.0, 10.0, 0, 0] * 1752),
+        marginal_costs: 0.0
+      )
+    end
+
+    let(:store_1) do
+      FactoryBot.build(
+        :storage,
+        input_capacity_per_unit: 10.0,
+        output_capacity_per_unit: 20.0,
+        marginal_costs: storage_1_prices[:out],
+        consumption_price: storage_1_prices[:in],
+        decay: ->(*) { 0.0 },
+        volume_per_unit: 100.0
+      )
+    end
+
+    let(:storage_1_prices) { { in: 1.0, out: 1.5 } }
+
+    before do
+      order = Merit::Order.new
+
+      order.add(producer)
+      order.add(export)
+      order.add(store_1)
+
+      order.calculate
+    end
+
+    it 'never exceeds the output capacity of the first store' do
+      expect(store_1.load_curve.values.min).to be >= -store_1.input_capacity_per_unit
+    end
+
+    it 'never exceeds the input capacity of the first store' do
+      expect(store_1.load_curve.values.max).to be <= store_1.output_capacity_per_unit
     end
   end
 end


### PR DESCRIPTION
The following was happening:
On the second iteration through the dispatchables (price sensitive) max_load_at was not limited by the output capacity left, but the total output capacity.

I am adding a test case for it so it doesn't happen again!

Closes quintel/etengine#1300