### PR TITLE
Hybrid Offshore Wind

### DIFF
--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -52,6 +52,7 @@ require_relative 'merit/flex/reserve'
 require_relative 'merit/flex/simple_reserve'
 require_relative 'merit/flex/storage'
 require_relative 'merit/flex/variable_consumer'
+require_relative 'merit/flex/with_satisfied_demand'
 
 require_relative 'merit/lole'
 require_relative 'merit/net_load_helper'

--- a/lib/merit/flex/base.rb
+++ b/lib/merit/flex/base.rb
@@ -72,7 +72,6 @@ module Merit
       # Returns the amount of energy which was assigned.
       def assign_excess(point, amount)
         input_cap = @input_capacity + @load_curve.get(point)
-
         amount = amount > input_cap ? input_cap : amount
         @load_curve.set(point, @load_curve.get(point) - amount)
 

--- a/lib/merit/flex/base.rb
+++ b/lib/merit/flex/base.rb
@@ -140,6 +140,10 @@ module Merit
       def flex?
         true
       end
+
+      def price_setting?(point)
+        true
+      end
     end
   end
 end

--- a/lib/merit/flex/with_satisfied_demand.rb
+++ b/lib/merit/flex/with_satisfied_demand.rb
@@ -2,13 +2,28 @@
 
 module Merit
   module Flex
-    # Flex participant with demand partially satisfied by a given satisfied_demand_curve
-    # A curve with negative values represents satisfied input
+    # Flex participant with demand partially satisfied by a given satisfied_demand_curve.
+    # The direct satisfied demand is not price setting.
+    #
+    # A curve with negative values represents satisfied input.
     class WithSatisfiedDemand < Base
       def initialize(opts)
         super
 
         @load_curve = Curve.new(opts[:satisfied_demand_curve])
+        @price_setting = Array.new(8760, false)
+      end
+
+      def price_setting?(point)
+        @price_setting[point]
+      end
+
+      def assign_excess(point, amount)
+        assigned = super
+
+        @price_setting[point] = true unless assigned.zero?
+
+        assigned
       end
     end
   end

--- a/lib/merit/flex/with_satisfied_demand.rb
+++ b/lib/merit/flex/with_satisfied_demand.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Merit
+  module Flex
+    # Flex participant with demand partially satisfied by a given satisfied_demand_curve
+    # A curve with negative values represents satisfied input
+    class WithSatisfiedDemand < Base
+      def initialize(opts)
+        super
+
+        @load_curve = Curve.new(opts[:satisfied_demand_curve])
+      end
+    end
+  end
+end

--- a/lib/merit/participants/types.rb
+++ b/lib/merit/participants/types.rb
@@ -13,6 +13,20 @@ module Merit
     end
   end
 
+  # A producer whose output is fixed, but part of production is constrained by
+  # external factors
+  class ConstrainedVolatileProducer < VolatileProducer
+    def initialize(opts)
+      super
+      @constraint = opts[:constraint]
+    end
+
+    def max_load_at(point)
+      amount = super
+      @constraint.call(point, amount).clamp(0.0, amount)
+    end
+  end
+
   # A producer whose output is fixed.
   class MustRunProducer < Producer
     def initialize(opts)

--- a/lib/merit/price_curve.rb
+++ b/lib/merit/price_curve.rb
@@ -102,7 +102,7 @@ module Merit
 
       collection = @price_sensitives.at_point(point)
 
-      index = collection.rindex { |ps| ps.load_at(point).negative? }
+      index = collection.rindex { |ps| ps.load_at(point).negative? && ps.price_setting?(point) }
       user = collection[index] if index
 
       if user.nil? && @inflex_consumer_marker&.active_at?(point)

--- a/spec/factories/flex.rb
+++ b/spec/factories/flex.rb
@@ -28,6 +28,10 @@ FactoryBot.define do
       initialize_with { Merit::Flex::VariableConsumer.new(attributes) }
     end
 
+    factory :with_satisfied_demand, class: 'Merit::Flex::WithSatisfiedDemand' do
+      initialize_with { Merit::Flex::WithSatisfiedDemand.new(attributes) }
+    end
+
     factory :export do
       consume_from_dispatchables { true }
       output_capacity_per_unit { 0.0 }

--- a/spec/factories/producer.rb
+++ b/spec/factories/producer.rb
@@ -46,5 +46,13 @@ FactoryBot.define do
       sequence(:key) { |n| :"variable_dispatchable_#{n}" }
       availability { [1.0] * 8760 }
     end
+
+    factory :constrained_volatile_producer, class: 'Merit::ConstrainedVolatileProducer' do
+      initialize_with { Merit::ConstrainedVolatileProducer.new(attributes) }
+
+      sequence(:key) { |n| :"constrained_volatile_producer_#{n}" }
+
+      load_profile { Merit::Curve.new([1.0 / 8760 / 3600] * Merit::POINTS) }
+    end
   end
 end

--- a/spec/integration/constrained_and_satisfied_demand_spec.rb
+++ b/spec/integration/constrained_and_satisfied_demand_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe 'Calculation of always ons and flex' do
       expect(producer.load_curve[0] - producer.max_load_at(0)).to eq(500)
     end
 
+    it 'the satisfied demand consumer is always price setting' do
+      expect(consumer.price_setting?(0)).to be_truthy
+    end
+
     context 'when there is an extra consumer with higher priority' do
       let(:order) do
         Merit::Order.new.tap do |order|
@@ -70,6 +74,35 @@ RSpec.describe 'Calculation of always ons and flex' do
 
       it 'constrains the max_load on the producer, but not the load_curve' do
         expect(producer.load_curve[0] - producer.max_load_at(0)).to eq(500)
+      end
+    end
+
+    context 'when there is an extra consumer that takes all excess energy' do
+      let(:order) do
+        Merit::Order.new.tap do |order|
+          order.add(producer)
+          order.add(consumer)
+          order.add(
+            build(
+              :flex,
+              marginal_costs: 100.0,
+              input_capacity_per_unit: 1000.0,
+              output_capacity_per_unit: 0
+            )
+          )
+        end
+      end
+
+      it 'assigns the satisfied demand to the satisfied-demand-consumer' do
+        expect(consumer.load_at(0)).to eq(-1 * consumption / 2.0)
+      end
+
+      it 'constrains the max_load on the producer, but not the load_curve' do
+        expect(producer.load_curve[0] - producer.max_load_at(0)).to eq(500)
+      end
+
+      it 'the satisfied demand consumer is never price setting' do
+        expect(consumer.price_setting?(0)).to be_falsey
       end
     end
   end

--- a/spec/integration/constrained_and_satisfied_demand_spec.rb
+++ b/spec/integration/constrained_and_satisfied_demand_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# This spec checks the integration between participants that have a constrained
+# production, and consumers that have a constrained demand. These components
+# should be able to work together in order to simulate a direct connection
+# between the two participants outside of the main market.
+
+RSpec.describe 'Calculation of always ons and flex' do
+  let(:order) do
+    Merit::Order.new.tap do |order|
+      order.add(producer)
+      order.add(consumer)
+    end
+  end
+
+  let(:producer) do
+    build(
+      :constrained_volatile_producer,
+      output_capacity_per_unit: production,
+      constraint: constraint
+    )
+  end
+
+  let(:consumer) do
+    build(
+      :with_satisfied_demand,
+      satisfied_demand_curve: satisfied_demand_curve,
+      input_capacity_per_unit: consumption
+    )
+  end
+
+  let(:production) { 1000 }
+  let(:consumption) { 1000 }
+
+  context 'with constraint being the same as satsfied demand' do
+    let(:constraint) { ->(_, _) { 500 } }
+    let(:satisfied_demand_curve) { Merit::Curve.new([-500] * Merit::POINTS) }
+
+    before { order.calculate }
+
+    it 'assigns the remaining energy to the consumer as well' do
+      expect(consumer.load_at(0)).to eq(-1 * consumption)
+    end
+
+    it 'constrains the max_load on the producer, but not the load_curve' do
+      expect(producer.load_curve[0] - producer.max_load_at(0)).to eq(500)
+    end
+
+    context 'when there is an extra consumer with higher priority' do
+      let(:order) do
+        Merit::Order.new.tap do |order|
+          order.add(producer)
+          order.add(consumer)
+          order.add(
+            build(
+              :flex,
+              marginal_costs: 10.0,
+              input_capacity_per_unit: 1000.0,
+              output_capacity_per_unit: 0
+            )
+          )
+        end
+      end
+
+      it 'assigns at least the satisfied demand to the satisfied-demand-consumer' do
+        expect(consumer.load_at(0)).to be <= (-1 * consumption / 2.0)
+      end
+
+      it 'constrains the max_load on the producer, but not the load_curve' do
+        expect(producer.load_curve[0] - producer.max_load_at(0)).to eq(500)
+      end
+    end
+  end
+
+  context 'when constraint returns a negative value' do
+    let(:constraint) { ->(_, _) { -500 } }
+    let(:satisfied_demand_curve) { Merit::Curve.new([-500] * Merit::POINTS) }
+
+    before { order.calculate }
+
+    it 'assigns no extra energy to the consumer' do
+      expect(consumer.load_at(0)).to eq(-500)
+    end
+
+    it 'constrains the max_load on the producer to 0' do
+      expect(producer.max_load_at(0)).to eq(0)
+    end
+  end
+
+  context 'when constraint returns a value larger than the original max_load' do
+    let(:constraint) { ->(_, _) { 1500 } }
+    let(:satisfied_demand_curve) { Merit::Curve.new([-500] * Merit::POINTS) }
+
+    before { order.calculate }
+
+    it 'assigns the remaining energy to the consumer as well' do
+      expect(consumer.load_at(0)).to eq(-consumption)
+    end
+
+    it 'constrains the max_load on the producer to the orignal max_load' do
+      expect(producer.max_load_at(0)).to eq(production)
+    end
+  end
+
+  context 'when constraint is twice the amount of satisfied demand' do
+    let(:constraint) { ->(_, _) { 500 } }
+    let(:satisfied_demand_curve) { Merit::Curve.new([-250] * Merit::POINTS) }
+
+    before { order.calculate }
+
+    it 'has energy missing in the consumer' do
+      expect(consumer.load_at(0)).to eq(-750)
+    end
+
+    it 'has energy missing in the system' do
+      expect(consumer.load_at(0) + producer.load_curve[0]).not_to eq(0)
+    end
+  end
+
+  context 'when satisfied demand is larger than the input_capacity of the consumer' do
+    let(:constraint) { ->(_, _) { 1250 } }
+    let(:satisfied_demand_curve) { Merit::Curve.new([-1250] * Merit::POINTS) }
+
+    before { order.calculate }
+
+    it 'constrains the consumers hourly load' do
+      expect(consumer.load_at(0)).to eq(-consumption)
+    end
+
+    it 'constrains the consumers demand' do
+      expect(consumer.production).to eq(consumption * 8760 * 3600)
+    end
+
+    it 'constrains the producer' do
+      expect(producer.max_load_at(0)).to eq(production)
+    end
+  end
+end


### PR DESCRIPTION
With this PR the modelling of hybrid offshore wind is added to the ETM. This comes with, among others, the following features:

- Hybrid offshore wind turbine that can generate electricity for HV network or directly for connected offshore electrolyser
- Price-based offshore electrolyser that can receive electricity from hybrid wind turbine or from onshore HV network
- Front-end sliders to set installed (relative) capacities of the components and other relevant specs (e.g. costs, full load hours)
-  3 new front-end outputs: a bar chart, Sankey diagram and table that provide data on capacities and energy flows of hybrid offshore wind

Goes with:

https://github.com/quintel/documentation/pull/195
https://github.com/quintel/etsource/pull/3067
https://github.com/quintel/etlocal/pull/524
https://github.com/quintel/etmodel/pull/4290
https://github.com/quintel/etdataset/pull/1001
https://github.com/quintel/etengine/pull/1440