### PR TITLE
Add methods for peak and volume of blackout hours

### DIFF
--- a/lib/merit/blackout.rb
+++ b/lib/merit/blackout.rb
@@ -2,14 +2,30 @@
 
 module Merit
   # Computes the number of hours in which there is insufficient production to
-  # meet demand.
+  # meet demand, plus the volume and peak of those shortfalls.
   class Blackout
+    EPSILON = 1e-5
+
     def initialize(net_load)
       @net_load = net_load
     end
 
+    # Number of hours with a shortfall
     def number_of_hours
-      @net_load.count { |val| val < -1e-5 }
+      @net_load.count { |val| val < -EPSILON }
+    end
+
+    # Total volume of shortfall (sum of all deficits)
+    def volume
+      @net_load
+        .select { |val| val < -EPSILON }    # only deficit hours
+        .sum     { |val| -val }             # flip sign and sum
+    end
+
+    # Peak hourly shortfall (the largest single-hour deficit)
+    def peak
+      worst = @net_load.min                # most negative value
+      worst < -EPSILON ? -worst : 0.0      # if it’s a deficit, flip sign; otherwise return zero
     end
   end
 end

--- a/lib/merit/blackout.rb
+++ b/lib/merit/blackout.rb
@@ -24,8 +24,8 @@ module Merit
 
     # Peak hourly shortfall (the largest single-hour deficit)
     def peak
-      worst = @net_load.min                # most negative value
-      worst < -EPSILON ? -worst : 0.0      # if it’s a deficit, flip sign; otherwise return zero
+      minimum = @net_load.min                # most negative value
+      minimum < -EPSILON ? -minimum : 0.0      # if it’s a deficit, flip sign; otherwise return zero
     end
   end
 end

--- a/spec/merit/blackout_spec.rb
+++ b/spec/merit/blackout_spec.rb
@@ -5,12 +5,21 @@ require 'spec_helper'
 module Merit
   RSpec.describe Blackout do
     let(:blackout) { described_class.new(net_load) }
+    let(:eps) { described_class::EPSILON }
 
     context 'when the net load is constant 0' do
       let(:net_load)  { [0.0] * 8760 }
 
       it 'has no blackout hours' do
         expect(blackout.number_of_hours).to eq(0)
+      end
+
+      it 'has zero blackout volume' do
+        expect(blackout.volume).to eq(0)
+      end
+
+      it 'has zero blackout peak' do
+        expect(blackout.peak).to eq(0.0)
       end
     end
 
@@ -20,6 +29,14 @@ module Merit
       it 'has no blackout hours' do
         expect(blackout.number_of_hours).to eq(0)
       end
+
+      it 'has zero blackout volume' do
+        expect(blackout.volume).to eq(0)
+      end
+
+      it 'has zero blackout peak' do
+        expect(blackout.peak).to eq(0.0)
+      end
     end
 
     context 'when the net load is constant -1' do
@@ -28,6 +45,14 @@ module Merit
       it 'has 8760 blackout hours' do
         expect(blackout.number_of_hours).to eq(8760)
       end
+
+      it 'has correct blackout volume' do
+        expect(blackout.volume).to eq(8760.0)
+      end
+
+      it 'has correct blackout peak' do
+        expect(blackout.peak).to eq(1.0)
+      end
     end
 
     context 'when the net load alternates between -1 and 1' do
@@ -35,6 +60,46 @@ module Merit
 
       it 'has 4380 blackout hours' do
         expect(blackout.number_of_hours).to eq(4380)
+      end
+
+      it 'has correct blackout volume' do
+        expect(blackout.volume).to eq(4380.0)
+      end
+
+      it 'has correct blackout peak' do
+        expect(blackout.peak).to eq(1.0)
+      end
+    end
+
+    context 'when net load includes minor negatives above -EPSILON' do
+      let(:net_load) { [-eps / 2, -eps / 10, 0.0, 1.0] }
+
+      it 'ignores them as blackout hours' do
+        expect(blackout.number_of_hours).to eq(0)
+      end
+
+      it 'has zero blackout volume' do
+        expect(blackout.volume).to eq(0)
+      end
+
+      it 'has zero blackout peak' do
+        expect(blackout.peak).to eq(0.0)
+      end
+    end
+
+    context 'with a few clear deficit values' do
+      let(:net_load) { [-0.5, -2.0, 0.0, 1.0, -1.0] }
+
+      it 'counts correct blackout hours' do
+        expect(blackout.number_of_hours).to eq(3)
+      end
+
+      it 'calculates correct volume' do
+        expect(blackout.volume).to eq(3.5)
+      end
+
+      it 'calculates correct peak' do
+        expect(blackout.peak).to eq(2.0)
       end
     end
   end


### PR DESCRIPTION
**volume:**
- Takes the total volume of deficits
	- Select every hour which is a deficit
	- Add them together

**peak:**
- The largest single hour deficit
	- Find the most deficit value
	- Flip the sign, or return zero if it's already positive
	        - @kaskranenburgQ Is this the desired way of calculating this? Or should we return it as a negative, or should we return the flipped smallest value always even if that implies negative blackout hours?
