### PR TITLE
Optimizing storage technologies should be price flexible

### DIFF
--- a/lib/merit/flex/optimizing_storage.rb
+++ b/lib/merit/flex/optimizing_storage.rb
@@ -10,25 +10,12 @@ module Merit
     # optionally supports an output efficiency for modelling round-trip losses.
     module OptimizingStorage
       # Contains behavior for the production half of the optimizing storage.
-      #
-      # Production is determined by a curve. Unlike other always-on producers, optimizing storage
-      # has a price and can be used to set the hourly price in Merit::PriceCurve.
       class Producer < Merit::CurveProducer
-        def provides_price?
-          true
-        end
       end
 
       # Contains behavior for the consumption half of the optimizing storage.
-      #
-      # Consumption is determined by a curve. Unlike other users, optimizing storage has a price and
-      # can be used to set the hourly price in Merit::PriceCurve.
       class Consumer < Merit::User::WithCurve
         public_class_method :new
-
-        def provides_price?
-          true
-        end
       end
 
       # Stores each hour and its current value.
@@ -110,7 +97,7 @@ module Merit
           next if available_output_energy.zero?
 
           # Only charge from an hour whose value is 95% or less than the max frame value.
-          # This effectively ensures that a discharge hour will not be matched to a charge 
+          # This effectively ensures that a discharge hour will not be matched to a charge
           # hour of roughly the same value.
           desired_low = max_frame.value * 0.95
 


### PR DESCRIPTION
Remove price providing behaviour for optimising storage producer/consumer.

As described in [this issue](https://github.com/quintel/etengine/issues/1535), now Optimizing Storage technologies no longer set the price, but rather take their price flexibly like other flex technologies.

Goes with 