### PR TITLE
Prep gem for Ruby 4.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ blocks:
             - sem-version ruby $RUBY_VERSION
             - gem install bundler -v ">= 2.0"
             - bundle install
-            - bundle exec rspec --format RspecJunitFormatter --out junit.xml --format progress
+            - bundle exec rspec
           matrix:
             - env_var: RUBY_VERSION
               values:
@@ -22,7 +22,3 @@ blocks:
                 - '4.0'
       secrets:
         - name: Merit
-      epilogue:
-        always:
-          commands:
-            - test-results publish junit.xml

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,5 +18,5 @@ blocks:
           matrix:
             - env_var: RUBY_VERSION
               values:
-                - '3.3'
+                - '3.4'
                 - '4.0'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,5 +20,3 @@ blocks:
               values:
                 - '3.3'
                 - '4.0'
-      secrets:
-        - name: Merit

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,5 +18,5 @@ blocks:
           matrix:
             - env_var: RUBY_VERSION
               values:
-                - '3.4'
+                - '3.3'
                 - '4.0'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,8 +18,8 @@ blocks:
           matrix:
             - env_var: RUBY_VERSION
               values:
-                - 2.7.5
-                - 3.1.1
+                - '3.3'
+                - '4.0'
       secrets:
         - name: Merit
       epilogue:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'codecov', require: false
   gem 'factory_bot'
   gem 'pry', require: false
   gem 'simplecov', require: false

--- a/quintel_merit.gemspec
+++ b/quintel_merit.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',  '>= 0.9.0'
   s.add_development_dependency 'rspec', '>= 3.0'
 
+  s.add_dependency 'csv'
   s.add_dependency 'numo-narray'
   s.add_dependency 'terminal-table'
 end

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -7,9 +7,4 @@ if ENV['COVERAGE'] || ENV['CI']
     add_filter('/spec')
     add_filter('/lib/merit/point_table')
   end
-
-  if ENV['CI']
-    require 'codecov'
-    SimpleCov.formatter = SimpleCov::Formatter::Codecov
-  end
 end


### PR DESCRIPTION
#### Context

In an ongoing effort to prepare the internal gems for the upcoming Ruby4/Rails8 update, we updated their semaphore checks to use versions 3.3 and 4.0. Then run their RSpec tests locally against this 2 versions to identify any early issues (at gem level) and fix them.

#### Implemented changes

- refinery: Update Ruby version checks to 3.3/4.0
- fever: Update Ruby version checks to 3.3/4.0
- merit: Update Ruby version checks to 3.3/4.0 and add csv dependency
- atlas: Update Ruby version checks to 3.3/4.0 and lockfile/dependencies for Ruby 4.0 
- identity_rails: Add simplecov, update Ruby version checks to 3.3/4.0 and lockfile/dependencies for Ruby 4.0
- transformer: Add simplecov, unpin ruby-version then set Ruby version checks for 3.3/4.0 
- rubel: Add rspec and simplecov, fix some specs then set Ruby version checks for 3.3/4.0
- osmosis: Standarize simplecov, add bigdecimal dependency, fix some specs then set Ruby version checks for 3.3/4.0
- turbine: Standarize simplecov, add rspec-collection_matchers, fix specs then set Ruby version checks for 3.3/4.0

#### Related

Goes with pull requests:
- refinery: https://github.com/quintel/refinery/pull/63
- fever: https://github.com/quintel/fever/pull/2
- merit: https://github.com/quintel/merit/pull/160 [THIS ONE]
- atlas: https://github.com/quintel/atlas/pull/187
- identity_rails: https://github.com/quintel/identity_rails/pull/7
- transformer: https://github.com/quintel/transformer/pull/19
- rubel: https://github.com/quintel/rubel/pull/1
- osmosis: https://github.com/quintel/osmosis/pull/1
- turbine: https://github.com/quintel/turbine/pull/5

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review